### PR TITLE
[Conversion] Add reduce & binary op conversion, and I1Tensor support

### DIFF
--- a/include/triton-shared/Dialect/TritonStructured/IR/TritonStructuredDialect.td
+++ b/include/triton-shared/Dialect/TritonStructured/IR/TritonStructuredDialect.td
@@ -124,8 +124,14 @@ def TTS_GetStructuredStateOp : TTS_Op<"get_structured_state", [AttrSizedResultSe
   let summary = "Placeholder for the structured pointer states computed during PtrAnalysis.";
   let description = "Used to pass the offsets and strides to scf.for op to simplify IR rewrites.";
 
-  let arguments = (ins AnyTypeOf<[TT_PtrLike, I32Tensor, I64Tensor]>:$input);
-  let results = (outs AnyTypeOf<[TT_PtrLike, I32Tensor, I64Tensor]>:$structured, Variadic<Index>:$offsets, Variadic<Index>:$strides);
+  let arguments = (
+    ins AnyTypeOf<[TT_PtrLike, I1Tensor, I32Tensor, I64Tensor]>:$input
+  );
+  let results = (
+    outs AnyTypeOf<[TT_PtrLike, I1Tensor, I32Tensor, I64Tensor]>:$structured,
+    Variadic<Index>:$offsets,
+    Variadic<Index>:$strides
+  );
 
   let builders = [
     OpBuilder<(ins "Value":$input)>,

--- a/lib/Conversion/TritonToLinalg/CMakeLists.txt
+++ b/lib/Conversion/TritonToLinalg/CMakeLists.txt
@@ -10,6 +10,8 @@ add_triton_library(TritonToLinalg
 
   DEPENDS
   TritonToLinalgConversionPassIncGen
+  MLIRMathExtDialectIncGen
+  MLIRMathExtOpsIncGen
 
   LINK_LIBS PUBLIC
   TritonTilingExtIR


### PR DESCRIPTION
<!-- PR Title
[component] brief description
  component options:
    - BUILD
    - CI/CD
    - DOC
    - FRONTEND
    - BACKEND
    - AUTOTUNER
    - CACHE
    - LAYOUTS
    - PIPELINE
    - PROTON
    - TEST
    - OTHER
-->
1. Add reduce op conversion for subf, divf.
2. Add binary op conversion for atan2.
3. Add I1Tensor support in TritonStructuredDialect.
4. Fix dependency for MLIRMathExt.